### PR TITLE
Note: git branch is hardcoded to 'master'

### DIFF
--- a/macro/metrics_common.py
+++ b/macro/metrics_common.py
@@ -159,7 +159,7 @@ def get_metric_html(macro, data, container):
 	    	branch = str(uri_info).strip('[]').strip("''")
 	    	uri_0 = uri[0]
 	    	uri_cut = uri_0[6:-4]  	    
-	    	file_link = 'https://' + uri_cut + '/blob' + '/' + branch + '/' + val_string
+	    	file_link = 'https://' + uri_cut + '/blob' + '/' + 'master' + '/' + val_string
 
 	    ## svn
 	    elif 'svn' in vcs_type:


### PR DESCRIPTION
If you open files from the histograms, you will always get linked to the master branch. (Note: only valid for git)
