### PR TITLE
Deprecated badge

### DIFF
--- a/macro/headers.py
+++ b/macro/headers.py
@@ -295,7 +295,7 @@ def generate_package_header(macro, package_name, opt_distro=None):
     
     html = '<br><br>'.join([macro.formatter.rawHTML(item) for item in nav])
     if html:
-        html = html + '<br><br>'
+        html = html + '<br>'
 
     return html + links + desc 
 


### PR DESCRIPTION
Getting rid of one newline is okay. But if the second one would be removed too then the package-links would touch the navline. E.g. http://wiki.ros.org/roscpp
With only one newline the package-links will start one line above the package headline. But probably that is better then two empty newlines in some other cases.

@wjwwood Please review.
