### PR TITLE
Remove VersionName macro, use $ROS_DISTRO sentinal instead.

### DIFF
--- a/custom/js/rosversion.js
+++ b/custom/js/rosversion.js
@@ -23,7 +23,10 @@ function Version(sections) {
   $(".versionhide").removeClass("versionhide").filter("span").hide().end().filter("div").hide();
 
   if (sections.show[0]) {
-    $(".rosversion_name").text(sections.show[0]);
+    var name = sections.show[0];
+    var capitalized_name = name.charAt(0).toUpperCase() + name.slice(1);
+    $(".rosversion_name").text(name);
+    $(".rosversion_name_cap").text(capitalized_name);
   }
 }
 
@@ -45,6 +48,15 @@ $(document).ready(function() {
   var url_distro = getURLParameter('distro');
   if (url_distro) {
     activedistro=url_distro;
+  }
+  // Make the %ROSDISTRO%/%rosdistro% syntax work by wrapping them in spans. This is
+  // necessary vs. MoinMoin macros because macros are not expanded in code blocks.
+  var original = $("#page").html();
+  var replaced = original.
+    replace(/%ROSDISTRO%/g,'<span class="rosversion_name_cap">%ROSDISTRO%</span>').
+    replace(/%rosdistro%/g,'<span class="rosversion_name">%rosdistro%</span>');
+  if (original != replaced) {
+    $("#page").html(replaced);
   }
   $("div.version").hide();
   if ($("#"+activedistro).length > 0) {

--- a/custom/js/rosversion.js
+++ b/custom/js/rosversion.js
@@ -23,10 +23,7 @@ function Version(sections) {
   $(".versionhide").removeClass("versionhide").filter("span").hide().end().filter("div").hide();
 
   if (sections.show[0]) {
-    var name = sections.show[0];
-    var capitalized_name = name.charAt(0).toUpperCase() + name.slice(1);
-    $(".rosversion_name").text(name);
-    $(".rosversion_name_cap").text(capitalized_name);
+    $(".rosversion_name").text(sections.show[0]);
   }
 }
 
@@ -49,12 +46,23 @@ $(document).ready(function() {
   if (url_distro) {
     activedistro=url_distro;
   }
-  // Make the %ROSDISTRO%/%rosdistro% syntax work by wrapping them in spans. This is
-  // necessary vs. MoinMoin macros because macros are not expanded in code blocks.
+  // Make the $ROS_DISTRO replacement work by wrapping it in a span. This is
+  // necessary vs. MoinMoin macros because macros are not expanded inside of
+  // code blocks, where this replacement is most useful. Using a function for
+  // the replacement allows supporting escapes, so that the following transformations
+  // are done:
+  //   $ROS_DISTRO -> hydro, indigo, etc.
+  //   \$ROS_DISTRO -> $ROS_DISTRO
+  //   \\$ROS_DISTRO -> \$ROS_DISTRO
   var original = $("#page").html();
-  var replaced = original.
-    replace(/%ROSDISTRO%/g,'<span class="rosversion_name_cap">%ROSDISTRO%</span>').
-    replace(/%rosdistro%/g,'<span class="rosversion_name">%rosdistro%</span>');
+  var replaced = original.replace(/\\?\$ROS_DISTRO/g,
+    function(match) {
+      if (match[0] == "\\") {
+        return "$ROS_DISTRO";
+      } else {
+        return "<span class=\"rosversion_name\">$ROS_DISTRO</span>";
+      }
+    });
   if (original != replaced) {
     $("#page").html(replaced);
   }

--- a/macro/VersionName.py
+++ b/macro/VersionName.py
@@ -1,8 +1,0 @@
-# Trivially simple plugin, just generates an HTML hook
-# for rosversion.js to manipulate.
-
-Dependencies = []
-
-def execute(macro, args):
-    html = '<span class="rosversion_name">DISTRO</span>'
-    return macro.formatter.rawHTML(html)


### PR DESCRIPTION
Alternative to #113, addressing the same use-case.

%ROSDISTRO% becomes Hydro, Indigo, Jade
%rosdistro% becomes hydro, indigo, jade

Both work anywhere inside `<div id="page">`, including in code blocks.