### PR TITLE
Only replace $ROS_DISTRO inside p and pre.

### DIFF
--- a/custom/js/rosversion.js
+++ b/custom/js/rosversion.js
@@ -54,18 +54,17 @@ $(document).ready(function() {
   //   $ROS_DISTRO -> hydro, indigo, etc.
   //   \$ROS_DISTRO -> $ROS_DISTRO
   //   \\$ROS_DISTRO -> \$ROS_DISTRO
-  var original = $("#page").html();
-  var replaced = original.replace(/\\?\$ROS_DISTRO/g,
-    function(match) {
-      if (match[0] == "\\") {
-        return "$ROS_DISTRO";
-      } else {
-        return "<span class=\"rosversion_name\">$ROS_DISTRO</span>";
-      }
-    });
-  if (original != replaced) {
-    $("#page").html(replaced);
-  }
+  $("#page p:contains($ROS_DISTRO), #page pre:contains($ROS_DISTRO)").each(function() {
+    $(this).html($(this).html().replace(/\\?\$ROS_DISTRO/g,
+      function(match) {
+        if (match[0] == "\\") {
+          return "$ROS_DISTRO";
+        } else {
+          return "<span class=\"rosversion_name\">$ROS_DISTRO</span>";
+        }
+      })
+    );
+  });
   $("div.version").hide();
   if ($("#"+activedistro).length > 0) {
     $("#"+activedistro).click();


### PR DESCRIPTION
I believe this should resolve #115. Specifically, the replacement is now done only in p and pre elements, and done element-by-element rather than across the entire #page.

I've verified that this does the right thing on locally-saved copies of the tf tutorial introduction, and the page which edits the tf tutorial introduction.

Sorry for the interruption in service.