### PR TITLE
add robot page macros

### DIFF
--- a/macro/RobotEntry.py
+++ b/macro/RobotEntry.py
@@ -1,0 +1,37 @@
+"""
+This macro should be used in conjunction with the RobotTable macro to render
+a list of robots with an image and a link as a grid structure of thumbnails.
+
+This macro accepts exactly three arguments, the robot name as it should be
+displayed under the image, an image, and a link:
+
+    <<RobotEntry(Robot Name, attachment:robot_image.png, RobotName)>>
+
+The image can be an absolute url or it can be a wiki attachment.
+Wiki attached images should be preceded with `attachment:`.
+
+The link can be a relative wiki link like `RobotName/Tutorials` or an absolute
+url.
+"""
+
+
+Dependencies = []
+
+
+def execute(macro, args):
+    args = [a for a in args.split(',')]
+    if len(args) < 3:
+        return macro.formatter.text(
+            macro.name + ": Error parsing arguments: " + args)
+    if len(args) > 3:
+        args = [u', '.join(args[:-2])] + args[-2:]
+    args = [a.strip() for a in args]
+    if not hasattr(macro, 'robot_entries'):
+        macro.robot_entries = []
+    name, image, link = args
+    macro.robot_entries.append({
+        'name': name,
+        'link': link,
+        'image': image
+    })
+    return ""

--- a/macro/RobotTable.py
+++ b/macro/RobotTable.py
@@ -1,0 +1,48 @@
+"""
+This macro is used in conjunction with the RobotEntry macro like this:
+
+    <<RobotEntry(Robot Name, http://example.com/robot_name.png, RobotName)>>
+    <<RobotEntry(My Robot, attachment:my_robot.png, MyRobot/Tutorials)>>
+
+    <<RobotTable()>>
+
+The call to the RobotTable macro renders the robot entries which preceed it
+in a grid layout, in alphabetical order according to the robot name.
+"""
+
+
+Dependencies = []
+
+
+def execute(macro, args):
+    f = macro.formatter
+    result = ""
+    if not hasattr(macro, 'robot_entries'):
+        result = f.emphasis(1)
+        result += f.text(macro.name +
+                         " please use the <<RobotEntry()>> macro at least "
+                         "once before calling.")
+        result += f.emphasis(0)
+    result += f.div(1, css_class='row')
+    # Sort the robot entries before displaying
+    entries = sorted(macro.robot_entries,
+                     key=lambda entry: entry['name'].lower())
+    for entry in entries:
+        result += f.div(1, css_class='col-xs-6 col-sm-3 col-md-3')
+        result += f.div(1, css_class='thumbnail', style="width: 175px; height: 150px")
+        result += f.url(1, url=entry['link'])
+        image = entry['image']
+        image_style = "max-width: 150px; height: 75px"
+        if image.startswith('attachment:'):
+            result += f.attachment_image(image.split('attachment:')[1],
+                                         style=image_style)
+        else:
+            result += f.image(src=entry['image'], style=image_style)
+        result += f.div(1, css_class='caption')
+        result += f.text(entry['name'])
+        result += f.div(0)
+        result += f.url(0)
+        result += f.div(0)
+        result += f.div(0)
+    result += f.div(0)
+    return result


### PR DESCRIPTION
This pull request introduces two new macros `RobotEntry` and `RobotTable`. To use it you list many `RobotEntry` calls and then render it as a table of robot thumbnails by calling `RobotTable`. I tested this locally on all of the existing entries, converting the wiki syntax using this script:

https://github.com/ros-infrastructure/ros.org_scripts/commit/d2fdaf4a6f772bf5983cdcbcaed281a27321161e

The result looks something like this:

![screen shot 2015-03-09 at 7 22 59 pm](https://cloud.githubusercontent.com/assets/100427/6568364/90b3e626-c693-11e4-81b8-48244d6e75ad.png)

And the source is something like this:

```
<<RobotEntry(Adept MobileRobots Pioneer family (P3DX, P3AT, ...), attachment:amr-p3dx-robot-100x75.jpg, Robots/AMR_Pioneer_Compatible)>>
<<RobotEntry(Adept MobileRobots Pioneer LX, attachment:amr-pioneerlx-robot-100x75.jpg, Robots/AMR_Pioneer_Compatible)>>
<<RobotEntry(Adept MobileRobots Seekur family (Seekur, Seekur Jr.), attachment:amr-seekurjr-robot-100x75.jpg, Robots/AMR_Pioneer_Compatible)>>
<<RobotEntry(Aldebaran Nao, http://ros.org/images/installation/nao.jpg, Robots/Nao)>>
<<RobotEntry(Allegro Hand SimLab, attachment:AllegroHandIcon.png, Robots/AllegroHand)>>
<<RobotEntry(AMIGO, attachment:amigo.png, Robots/AMIGO)>>
<<RobotEntry(AscTec Quadrotor, attachment:asctec75.png, Robots/AscTec)>>
<<RobotEntry(Barrett Hand, attachment:bhand_282.jpg, Robots/BarrettHand)>>
<<RobotEntry(BipedRobin, attachment:bipedrobin.jpg, BipedRobin)>>
<<RobotEntry(Clearpath Robotics Grizzly, attachment:Grizzly Icon - Small.png, Robots/Grizzly)>>
<<RobotEntry(Clearpath Robotics Husky, attachment:Husky Icon - Small.jpg, Robots/Husky)>>
<<RobotEntry(Clearpath Robotics Jackal, attachment:Jackal Icon.png, Robots/Jackal)>>
<<RobotEntry(Clearpath Robotics Kingfisher, attachment:Kingfisher Icon - Small.jpg, Robots/Kingfisher)>>
<<RobotEntry(CoroWare Corobot, attachment:Corobot.jpg, Robots/Corobot)>>
<<RobotEntry(Cyton-Gamma, http://outgoing.energid.info/ROS/wiki/images/gamma-mini.png, Robots/Cyton-Gamma)>>
<<RobotEntry(Denso VS060, http://www.densorobot.co.uk/images/294/1/VS060-Products.jpg, densowave)>>
<<RobotEntry(Dr. Robot Jaguar, http://jaguar.drrobot.com/images/jaguarV4Arm_100.jpg, Robots/Jaguar)>>
<<RobotEntry(Eddiebot, attachment:eddiebot_small.png, eddiebot)>>
<<RobotEntry(Erle-brain, https://erlerobotics.com/blog/wp-content/uploads/2014/06/erlebrain-focus.png, Robots/Erle-brain)>>
<<RobotEntry(Erle-copter, https://erlerobotics.com/blog/wp-content/uploads/2015/01/6.png, Robots/Erle-copter)>>
<<RobotEntry(Erle-HexaCopter, https://erlerobotics.com/blog/wp-content/uploads/2015/02/12.png, Robots/Erle-HexaCopter)>>
<<RobotEntry(Festo Didactic Robotino, attachment:Robotino75.png, Robots/Robotino)>>
<<RobotEntry(Fraunhofer IPA Care-O-bot 3, http://ros.org/images/installation/care.jpg, Robots/Care-O-bot)>>
<<RobotEntry(Fraunhofer IPA Care-O-bot 4, attachment:Care-O-bot_4.jpg, Robots/Care-O-bot)>>
<<RobotEntry(Gostai Jazz, attachment:GostaiJazz.png, Robots/Jazz)>>
<<RobotEntry(Innok Heros, attachment:innok-heros-thumb.jpg, Robots/Innok-Heros)>>
<<RobotEntry(Intel Edison, https://erlerobotics.com/blog/wp-content/uploads/2015/01/SparkFun_Edison_Boards-14.jpg, Edison)>>
<<RobotEntry(iRobot Roomba, http://ros.org/images/installation/roomba.jpg, Robots/Roomba)>>
<<RobotEntry(Kawada Nextage / Hiro, http://i.i.cbsi.com/cnwk.1d/i/tim/2011/11/09/Nextage1.JPG, rtmros_nextage)>>
<<RobotEntry(Kinova JACO, http://www.clearpathrobotics.com/wp-content/uploads/2013/05/JACO_Resting-at-its-side2.jpg, Robots/JACO)>>
<<RobotEntry(Kinova MICO, attachment:Mico2.jpg, Robots/MICO)>>
<<RobotEntry(Kobuki, attachment:kobuki-icon.png, kobuki)>>
<<RobotEntry(Komodo, attachment:Komodo.jpg, ric)>>
<<RobotEntry(Lego NXT, http://ros.org/images/installation/nxt.jpg, Robots/NXT)>>
<<RobotEntry(Lizi, attachment:lizi.jpg, ric)>>
<<RobotEntry(Maggie, attachment:maggie_small.png, Robots/Maggie)>>
<<RobotEntry(Merlin miabotPro, http://ros.org/images/installation/miabot.jpg, Robots/miabotPro)>>
<<RobotEntry(Nav2, attachment:virtualme.png, Robots/Nav2)>>
<<RobotEntry(Neobotix mp-500, attachment:mp-500.jpg, Robots/neobotix)>>
<<RobotEntry(Neobotix mpo-500, attachment:mpo-500.jpg, Robots/neobotix)>>
<<RobotEntry(Neobotix mpo-700, attachment:mpo-700.jpg, Robots/neobotix)>>
<<RobotEntry(Otto Bock SensorHand Speed, attachment:sensorhand_speed.jpg, Robots/sensorhand_speed)>>
<<RobotEntry(PAL Robotics REEM-C, attachment:reemc-icon.png, Robots/REEM-C)>>
<<RobotEntry(REEM, attachment:reem_icon.jpg, Robots/REEM)>>
<<RobotEntry(Robonaut 2, attachment:robonaut2.jpg, Robots/Robonaut2)>>
<<RobotEntry(Robotnik Agvs, attachment:agvs_robot_1.jpg, Robots/Agvs)>>
<<RobotEntry(Robotnik Guardian, http://i47.tinypic.com/348sux2.jpg, Robots/Guardian)>>
<<RobotEntry(Robotnik Modular Arm, http://i40.tinypic.com/x29a45.jpgpg, Robots/modular_arm)>>
<<RobotEntry(Robotnik Summit, http://i41.tinypic.com/50ql3l.png, Robots/Summit)>>
<<RobotEntry(Robotnik SummitXL, http://i50.tinypic.com/259xyex.png, Robots/SummitXL)>>
<<RobotEntry(ROS-Industrial, attachment:motomanSIA10D.jpg, Industrial)>>
<<RobotEntry(Shadow Hand, http://ros.org/images/installation/shadow_hand75.png, Robots/Shadow_Hand)>>
<<RobotEntry(TUlip, attachment:tulip_small.jpg, Robots/TUlip)>>
<<RobotEntry(TurtleBot, attachment:turtlebot2_front.jpg, Robots/TurtleBot)>>
<<RobotEntry(Videre Erratic, http://ros.org/images/installation/videre.png, Robots/Erratic)>>
<<RobotEntry(WheeledRobin, attachment:wheeledrobin.jpg, WheeledRobin)>>
<<RobotEntry(Willow Garage PR2, http://ros.org/images/installation/pr2.jpg, Robots/PR2)>>
<<RobotEntry(Xaxxon Oculus Prime, http://www.xaxxon.com/images/oculusprime/oculusprime_elevation_150.jpg, Robots/Oculus_Prime)>>

<<RobotTable()>>
```