### PR TITLE
Added support for _and_newer and _and_older suffixes in Version macro

### DIFF
--- a/macro/Version.py
+++ b/macro/Version.py
@@ -12,6 +12,25 @@
 # - Automatically label the sections as "c-turtle only" so people see the
 #   changes?
 
+"""
+Example:
+
+    <<Version()>>
+
+    {{{#!wiki version fuerte_and_older
+    This is fuerte and older
+    }}}
+
+    {{{#!wiki version groovy
+    This is groovy
+    }}}
+
+    {{{#!wiki version hydro_and_newer
+    This is hydro and newer
+    }}}
+
+"""
+
 Dependencies = []
 
 # configure the active set of distros
@@ -36,8 +55,21 @@ def execute(macro, args):
                     'New in %s</span>' % version)
 
     def distro_html(distro, distros):
-        active = [distro.encode("iso-8859-1")]
-        inactive = [x.encode("iso-8859-1") for x in distros if not x == distro]
+        sorted_distros = sorted(distros)
+        # distro is guaranteed to be in distros
+        assert(distro in distros)
+        distro_index = sorted_distros.index(distro)
+        preceding_distros = sorted_distros[:distro_index + 1]
+        proceeding_distros = sorted_distros[distro_index:]
+
+        active = [(d + '_and_newer') for d in preceding_distros]
+        active += [(d + '_and_older') for d in proceeding_distros]
+        active.append(distro)
+        active = [d.encode("iso-8859-1") for d in active]
+        inactive = [(d + '_and_newer') for d in proceeding_distros]
+        inactive += [(d + '_and_older') for d in preceding_distros]
+        inactive += [d for d in distros if d != distro]
+        inactive = [d.encode("iso-8859-1") for d in inactive]
         sectionarg = '{show:%s, hide:%s}' % (active, inactive)
         html = (
             '''<button id="%s" class="btn btn-default" '''
@@ -46,6 +78,11 @@ def execute(macro, args):
             (distro, sectionarg)
         )
         for inactive_distro in inactive:
+            if (
+                inactive_distro.endswith('_and_newer') or
+                inactive_distro.endswith('_and_older')
+            ):
+                continue
             html += (
                 '''document.getElementById('%s').style.background='#e6e6e6';'''
                 '''document.getElementById('%s').style.color='#3e4f6e';''' %


### PR DESCRIPTION
Previously you had to explicitly state for each block which ROS distro's were applicable, but now you can do something like this:

```
<<Version()>>

{{{#!wiki version fuerte_and_older
This is fuerte and older
}}}

{{{#!wiki version groovy
This is groovy
}}}

{{{#!wiki version hydro_and_newer
This is hydro and newer
}}}
```

Fixes: #110