### PR TITLE
Center caption under RobotEntry image

### DIFF
--- a/macro/RobotTable.py
+++ b/macro/RobotTable.py
@@ -38,7 +38,7 @@ def execute(macro, args):
                                          style=image_style)
         else:
             result += f.image(src=entry['image'], style=image_style)
-        result += f.div(1, css_class='caption')
+        result += f.div(1, css_class='caption', style="text-align: center")
         result += f.text(entry['name'])
         result += f.div(0)
         result += f.url(0)


### PR DESCRIPTION
The markup generated by the `RobotTable(..)` macro doesn't centre the caption under the image, which would make the page look a bit nicer, imho.

Proposed change adds some in-line style to centre the text, as I was unsure of the impact of adding the rule to the `caption` class itself, but that could be changed of course.
