### PR TITLE
Update GitHubIssues macro text to reflect it also shows PRs (not just issues).

### DIFF
--- a/macro/GitHubIssues.py
+++ b/macro/GitHubIssues.py
@@ -13,12 +13,12 @@ def execute(macro, args):
   text = f.text
   url = f.url
   base = "https://github.com/%s/issues"%(project)
-  base_q = base + "?page=1&state=open"
+  base_q = base + "?page=1&q=state:open"
   base_new = base + "/new"
 
   output = text("Use GitHub to ") + url(1, base_new) + text("report bugs or submit feature requests") + url(0)  + text(". ")
   if component:
     output += text("Please use '%s:' at the beginning of the title. "%component)
 
-  output += text("[") + url(1,base_q) + text("View active issues") + url(0) + text("]") + f.linebreak(0)
+  output += text("[") + url(1,base_q) + text("View active issues and open PRs") + url(0) + text("]") + f.linebreak(0)
   return output


### PR DESCRIPTION
Only showing issues seems to be more in-line with the link text generated by the macro ("[View active issues]").

The old filter made GitHub include PRs as well.
