### PR TITLE
use new google embedded API for youtube

### DIFF
--- a/macro/Youtube.py
+++ b/macro/Youtube.py
@@ -4,4 +4,4 @@ def execute(macro, args):
   key = args.split()[0]
   if key.startswith('http://www.youtube.com/watch?v='):
     key = key[len('http://www.youtube.com/watch?v='):]
-  return macro.formatter.rawHTML('<object width="480" height="295"><param name="movie" value="http://www.youtube.com/v/%(key)s&hl=en_US&fs=1&hd=1"></param><param name="allowFullScreen" value="true"></param><param name="allowscriptaccess" value="always"></param><embed src="http://www.youtube.com/v/%(key)s&hl=en_US&fs=1&hd=1" type="application/x-shockwave-flash" allowscriptaccess="always" allowfullscreen="true" width="480" height="295"></embed></object>'%locals())
+  return macro.formatter.rawHTML('<center><iframe type="text/html" width="480" height="270" src="http://www.youtube.com/embed/%(key)s" frameborder="0" /></center>'%locals())

--- a/macro/Youtube.py
+++ b/macro/Youtube.py
@@ -4,4 +4,5 @@ def execute(macro, args):
   key = args.split()[0]
   if key.startswith('http://www.youtube.com/watch?v='):
     key = key[len('http://www.youtube.com/watch?v='):]
+  key = key.replace('&', '?', 1) # query params must start with ?
   return macro.formatter.rawHTML('<center><iframe type="text/html" width="480" height="270" src="http://www.youtube.com/embed/%(key)s" frameborder="0" allowfullscreen /></center>'%locals())

--- a/macro/Youtube.py
+++ b/macro/Youtube.py
@@ -4,4 +4,4 @@ def execute(macro, args):
   key = args.split()[0]
   if key.startswith('http://www.youtube.com/watch?v='):
     key = key[len('http://www.youtube.com/watch?v='):]
-  return macro.formatter.rawHTML('<center><iframe type="text/html" width="480" height="270" src="http://www.youtube.com/embed/%(key)s" frameborder="0" /></center>'%locals())
+  return macro.formatter.rawHTML('<center><iframe type="text/html" width="480" height="270" src="http://www.youtube.com/embed/%(key)s" frameborder="0" allowfullscreen /></center>'%locals())


### PR DESCRIPTION
this allows to use HTML5 instead of flash.

Citing google:

> Deprecation Notice
> YouTube `<object>` embeds were deprecated on January 27, 2015. Please migrate your applications to use `<iframe>` embeds, which can intelligently use whichever embedded player – HTML (`<video>`) or Flash (`<object>`) – the client supports.

and

> Best practice: IFrame embeds are the recommended method for embedding a YouTube player because the IFrame will select the appropriate player based on the client's capabilities and available YouTube file formats.

I have added `<center>` to follow the same formatting as Vimeo videos. Minimal size is based on google recomendation.

> Note: Embedded players must have a viewport that is at least 200px by 200px. If the player displays controls, it must be large enough to fully display the controls without shrinking the viewport below the minimum size. We recommend 16:9 players be at least 480 pixels wide and 270 pixels tall.

Reference:
https://developers.google.com/youtube/player_parameters

EDIT: fix style