### PR TITLE
fix closing tag in youtube macro

### DIFF
--- a/macro/Youtube.py
+++ b/macro/Youtube.py
@@ -5,4 +5,4 @@ def execute(macro, args):
   if key.startswith('http://www.youtube.com/watch?v='):
     key = key[len('http://www.youtube.com/watch?v='):]
   key = key.replace('&', '?', 1) # query params must start with ?
-  return macro.formatter.rawHTML('<center><iframe type="text/html" width="480" height="270" src="http://www.youtube.com/embed/%(key)s" frameborder="0" allowfullscreen /></center>'%locals())
+  return macro.formatter.rawHTML('<center><iframe type="text/html" width="480" height="270" src="http://www.youtube.com/embed/%(key)s" frameborder="0" allowfullscreen></iframe></center>'%locals())


### PR DESCRIPTION
`/>` works only in xml mode as desired. in html mode this causes failure.