### PR TITLE
add lunar to version macro, possible fix for eol distros in status bar

### DIFF
--- a/macro/PackageHeader.py
+++ b/macro/PackageHeader.py
@@ -1,15 +1,13 @@
 from MoinMoin.Page import Page
 from MoinMoin.wikiutil import get_unicode
 
-from macroutils import load_package_manifest, distro_names, CONTRIBUTE_TMPL, UtilException
+from macroutils import load_package_manifest, distro_names, distro_names_hidden, CONTRIBUTE_TMPL, UtilException
 from headers import get_nav, get_description, get_package_links, generate_package_header, distro_html, doc_html, get_loaded_distros
 
 generates_headings = True
 dependencies = []
 
-hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'unstable']
-
-distro_names = [d for d in distro_names if d not in hidden_distros]
+distro_names = [d for d in distro_names if d not in distro_names_hidden]
 
 def generate_old_package_header(macro, package_name, opt_distro=None):
     if not package_name:

--- a/macro/PackageHeader.py
+++ b/macro/PackageHeader.py
@@ -7,7 +7,7 @@ from headers import get_nav, get_description, get_package_links, generate_packag
 generates_headings = True
 dependencies = []
 
-hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'unstable']
+hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'unstable']
 
 for hidden_distro in hidden_distros if hidden_distro in distro_names:
     distro_names.remove(hidden_distro)

--- a/macro/PackageHeader.py
+++ b/macro/PackageHeader.py
@@ -9,9 +9,7 @@ dependencies = []
 
 hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'unstable']
 
-for hidden_distro in hidden_distros if hidden_distro in distro_names:
-    distro_names.remove(hidden_distro)
-
+distro_names = [d for d in distro_names if d not in hidden_distros]
 
 def generate_old_package_header(macro, package_name, opt_distro=None):
     if not package_name:

--- a/macro/PackageHeader.py
+++ b/macro/PackageHeader.py
@@ -7,14 +7,11 @@ from headers import get_nav, get_description, get_package_links, generate_packag
 generates_headings = True
 dependencies = []
 
-if 'boxturtle' in distro_names:
-    distro_names.remove('boxturtle')
-if 'cturtle' in distro_names:
-    distro_names.remove('cturtle')
-if 'diamondback' in distro_names:
-    distro_names.remove('diamondback')
-if 'unstable' in distro_names:
-    distro_names.remove('unstable')
+hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'unstable']
+
+for hidden_distro in hidden_distros if hidden_distro in distro_names:
+    distro_names.remove(hidden_distro)
+
 
 def generate_old_package_header(macro, package_name, opt_distro=None):
     if not package_name:

--- a/macro/StackHeader.py
+++ b/macro/StackHeader.py
@@ -8,14 +8,11 @@ from headers import get_nav, get_description, get_package_links, generate_packag
 generates_headings = True
 dependencies = []
 
-if 'boxturtle' in distro_names:
-    distro_names.remove('boxturtle')
-if 'cturtle' in distro_names:
-    distro_names.remove('cturtle')
-if 'diamondback' in distro_names:
-    distro_names.remove('diamondback')
-if 'unstable' in distro_names:
-    distro_names.remove('unstable')
+hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'unstable']
+
+for hidden_distro in hidden_distros if hidden_distro in distro_names:
+    distro_names.remove(hidden_distro)
+
 
 def generate_old_stack_header(macro, stack_name, opt_distro=None):
     try:

--- a/macro/StackHeader.py
+++ b/macro/StackHeader.py
@@ -8,7 +8,7 @@ from headers import get_nav, get_description, get_package_links, generate_packag
 generates_headings = True
 dependencies = []
 
-hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'unstable']
+hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'unstable']
 
 for hidden_distro in hidden_distros if hidden_distro in distro_names:
     distro_names.remove(hidden_distro)

--- a/macro/StackHeader.py
+++ b/macro/StackHeader.py
@@ -2,15 +2,13 @@ import urllib2
 from MoinMoin.Page import Page
 from MoinMoin.wikiutil import get_unicode
 
-from macroutils import load_stack_manifest, load_package_manifest, distro_names, CONTRIBUTE_TMPL, UtilException
+from macroutils import load_stack_manifest, load_package_manifest, distro_names, distro_names_hidden, CONTRIBUTE_TMPL, UtilException
 from headers import get_nav, get_description, get_package_links, generate_package_header, distro_html, get_stack_links, doc_html, get_loaded_distros
 
 generates_headings = True
 dependencies = []
 
-hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'unstable']
-
-distro_names = [d for d in distro_names if d not in hidden_distros]
+distro_names = [d for d in distro_names if d not in distro_names_hidden]
 
 def generate_old_stack_header(macro, stack_name, opt_distro=None):
     try:

--- a/macro/StackHeader.py
+++ b/macro/StackHeader.py
@@ -10,9 +10,7 @@ dependencies = []
 
 hidden_distros = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'unstable']
 
-for hidden_distro in hidden_distros if hidden_distro in distro_names:
-    distro_names.remove(hidden_distro)
-
+distro_names = [d for d in distro_names if d not in hidden_distros]
 
 def generate_old_stack_header(macro, stack_name, opt_distro=None):
     try:

--- a/macro/Version.py
+++ b/macro/Version.py
@@ -36,9 +36,12 @@ from headers import distro_html
 Dependencies = []
 
 # configure the active set of distros
-from macroutils import distro_names, distro_names_hidden
+from macroutils import distro_names as distros
 
-distros = [d for d in distro_names if d not in distro_names_hidden]
+if 'boxturtle' in distros:
+    distros.remove('boxturtle')
+if 'unstable' in distros:
+    distros.remove('unstable')
 
 
 def execute(macro, args):

--- a/macro/Version.py
+++ b/macro/Version.py
@@ -36,12 +36,9 @@ from headers import distro_html
 Dependencies = []
 
 # configure the active set of distros
-from macroutils import distro_names as distros
+from macroutils import distro_names, distro_names_hidden
 
-if 'boxturtle' in distros:
-    distros.remove('boxturtle')
-if 'unstable' in distros:
-    distros.remove('unstable')
+distros = [d for d in distro_names if d not in distro_names_hidden]
 
 
 def execute(macro, args):

--- a/macro/Version.py
+++ b/macro/Version.py
@@ -45,7 +45,6 @@ def execute(macro, args):
     if args:
         version = str(args)
         if version.lower() == 'lunar':
-            # TODO Change when l-turtle name is decided
             return ('<span style="background-color:#FFFF00; '
                     'font-weight:bold; padding: 3px;">'
                     'Expected in Lunar</span>')

--- a/macro/Version.py
+++ b/macro/Version.py
@@ -47,11 +47,11 @@ if 'unstable' in distros:
 def execute(macro, args):
     if args:
         version = str(args)
-        if version.lower() == 'l-turtle':
+        if version.lower() == 'lunar':
             # TODO Change when l-turtle name is decided
             return ('<span style="background-color:#FFFF00; '
                     'font-weight:bold; padding: 3px;">'
-                    'Expected in L-Turtle</span>')
+                    'Expected in Lunar</span>')
         else:
             return ('<span style="background-color:#FFFF00; '
                     'font-weight:bold; padding: 3px;">'

--- a/macro/macroutils.py
+++ b/macro/macroutils.py
@@ -14,10 +14,12 @@ NETWORK_TIMEOUT = 3
 distro_names = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'unstable']
 distro_names_indexed = ['diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'unstable'] #boxturtle and cturtle not indexed
 distro_names_buildfarm = ['indigo', 'jade', 'kinetic']
+distro_names_hidden = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'unstable']
 
 doc_url = "http://docs.ros.org/"
 
 doc_path = '/home/rosbot/docs/'
+
 metrics_path = '/var/www/www.ros.org/metrics/'
 
 MISSING_DOC_TMPL = 'Cannot load information on <strong>%(name)s</strong>, which means that it is not yet in our index.'


### PR DESCRIPTION
I believe this will hide EOL'd distros from the package pages, but I'm not sure if this is the solution I'd like to settle on.
