### PR TITLE
instead of raising an exception place an error message into the page

### DIFF
--- a/macro/GetCode.py
+++ b/macro/GetCode.py
@@ -5,7 +5,7 @@
 
 """
 
-from urllib2 import HTTPError, urlopen
+from urllib2 import HTTPError, URLError, urlopen
 import StringIO
 import socket
 
@@ -36,10 +36,10 @@ def execute(macro, args):
     if uri not in cache:
         try:
             cache[uri] = urlopen(uri, timeout=macroutils.NETWORK_TIMEOUT).readlines()
-        except HTTPError as e:
-            raise macroutils.UtilException("Could not fetch external code from '%s': %s" % (uri, e))
+        except (HTTPError, URLError) as e:
+            return "<span style=\"color:red;font-weight:bold\">Could not fetch external code from '%s': %s</span>" % (uri, e)
         except socket.timeout as e:
-            raise macroutils.UtilException("Timed out while trying to access '%s'" % uri)
+            return "<span style=\"color:red;font-weight:bold\">Timed out while trying to access '%s'</span>" % uri
     lines = cache[uri]
     macro.request.cfg.get_tag_cache = dict(cache)
 

--- a/macro/GetTaggedCode.py
+++ b/macro/GetTaggedCode.py
@@ -6,7 +6,7 @@
 """
 
 import re
-from urllib2 import HTTPError, urlopen
+from urllib2 import HTTPError, URLError, urlopen
 import StringIO
 import socket
 
@@ -58,10 +58,10 @@ def execute(macro, args):
             cache[uri] = urlopen(uri, timeout=macroutils.NETWORK_TIMEOUT).readlines()
         except EOFError:
             return "GetTaggedCode can not fetch data from url '%s'" % uri
-        except HTTPError as e:
-            raise macroutils.UtilException("Could not fetch external code from '%s': %s" % (uri, e))
+        except (HTTPError, URLError) as e:
+            return "<span style=\"color:red;font-weight:bold\">Could not fetch external code from '%s': %s</span>" % (uri, e)
         except socket.timeout as e:
-            raise macroutils.UtilException("Timed out while trying to access '%s'" % uri)
+            return "<span style=\"color:red;font-weight:bold\">Timed out while trying to access '%s'</span>" % uri
     lines = cache[uri]
     macro.request.cfg.get_tag_cache = dict(cache)
 


### PR DESCRIPTION
With external services being unavailable without this patch the pages are basically not working since the page generation stops at the exception. With this patch the macros contribute an error message to the page but don't prevent generating the page.

Maybe other macros need the same - those two where the ones I saw in the Apache error logs.