### PR TITLE
add lunar to active distros

### DIFF
--- a/macro/Version.py
+++ b/macro/Version.py
@@ -47,11 +47,11 @@ if 'unstable' in distros:
 def execute(macro, args):
     if args:
         version = str(args)
-        if version.lower() == 'l-turtle':
-            # TODO Change when l-turtle name is decided
+        if version.lower() == 'm-turtle':
+            # TODO Change when m-turtle name is decided
             return ('<span style="background-color:#FFFF00; '
                     'font-weight:bold; padding: 3px;">'
-                    'Expected in L-Turtle</span>')
+                    'Expected in M-Turtle</span>')
         else:
             return ('<span style="background-color:#FFFF00; '
                     'font-weight:bold; padding: 3px;">'

--- a/macro/macroutils.py
+++ b/macro/macroutils.py
@@ -11,9 +11,9 @@ except ImportError:
 
 NETWORK_TIMEOUT = 3
 
-distro_names = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'unstable']
-distro_names_indexed = ['diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'unstable'] #boxturtle and cturtle not indexed
-distro_names_buildfarm = ['indigo', 'jade', 'kinetic']
+distro_names = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'lunar', 'unstable']
+distro_names_indexed = ['diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'lunar', 'unstable'] #boxturtle and cturtle not indexed
+distro_names_buildfarm = ['indigo', 'jade', 'kinetic', 'lunar']
 
 doc_url = "http://docs.ros.org/"
 


### PR DESCRIPTION
Note: this doesn't make lunar the default version, it only adds it to the lists of active distros