### PR TITLE
Add issue template with reference to the main wiki whitelist issue

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+<!--
+RE: ROS wiki whitelist:
+If you want your username added to the ROS wiki whitelist, you must add a comment with your wiki username on 
+https://github.com/ros-infrastructure/roswiki/issues/139
+Do not open a new issue.
+-->


### PR DESCRIPTION
FYI I'm adding this in an attempt to reduce the number of users opening issues to get added to the whitelist.