### PR TITLE
use raw html links in package header dependency lists

### DIFF
--- a/macro/headers.py
+++ b/macro/headers.py
@@ -572,7 +572,7 @@ def get_dependency_list(macro, data, css_prefix='', distro=None):
             ul(1)
         )
         for d in depends:
-            links += li(1) + wiki_url(macro, d, shorten=20, querystr=distro_query) + li(0)
+            links += li(1) + wiki_url(macro, d, shorten=20, querystr=distro_query, raw=True) + li(0)
         links += ul(0)+div(0)
     if depends_on:
         depends_on.sort()
@@ -584,7 +584,7 @@ def get_dependency_list(macro, data, css_prefix='', distro=None):
             strong(0) + "<br />" +
             '<div id="%sused-by-list" style="display:none">' % (css_prefix) + ul(1))
         for d in depends_on:
-            links += li(1) + wiki_url(macro, d, shorten=20, querystr=distro_query) + li(0)
+            links += li(1) + wiki_url(macro, d, shorten=20, querystr=distro_query, raw=True) + li(0)
         links += ul(0) + div(0)
 
     if links:

--- a/macro/macroutils.py
+++ b/macro/macroutils.py
@@ -92,14 +92,20 @@ def sub_link(macro, page, sub, title=None):
         title = sub
     return Page(macro.request, '%s/%s'%(page, sub)).link_to(macro.request, text=title)
 
-def wiki_url(macro, page,shorten=None,querystr=None):
+def wiki_url(macro, page,shorten=None,querystr=None, relative=False, raw=False):
     """
     Create link to ROS wiki page
+    @param raw: Return a raw html link instead of a wiki link. (This will avoid moin moin link checking.)
     """
     if not shorten or len(page) < shorten:
         page_text = page
     else:
         page_text = page[:shorten]+'...'
+    if raw:
+        ret = '<a href="'
+        ret += Page(macro.request, page).url(macro.request, querystr=querystr, relative=relative)
+        ret += '">%s</a>' % page_text
+        return ret
     return Page(macro.request, page).link_to(macro.request, text=page_text, querystr=querystr)
 
 def get_repo_li(macro, props):


### PR DESCRIPTION
After some debugging I have found that we were generating a lot of load for moin moin to check the links were active in the header. This meant that moin moin would attempt touch every wiki page of a dependent package before rendering.

With this implemented we drop from a load average of approximately 3 to close to 0.5 

Last night I truncated the list to 100 and performance improved enough to not have issues when the backup job ran at 4am. Now with the raw links instead of the wiki markdown links it's doing even better. 

![image](https://user-images.githubusercontent.com/447804/32127406-78210960-bb2b-11e7-9039-cec2a2a8ecb0.png)

It looks like it is even using less memory too.

For reference as our distros have grown things like catkin had over 500 dependencies causing every page load to need to touch 500 other pages before rendering. Most other packages are not that high, but the level of cross linking was significant.

The only effect on the user is that the links are not colored based on if they exist. They will have to click and get the 404 instead of knowing that they're not available. And to even see the links they must expand the listings so many users probably don't even see the color of the links.

The higher dependent count still takes longer to render due to generating the reverse dependencies on the fly still but it's back down to ~10 seconds for catkin instead of 30+ seconds.

---
Note that this is currently active on the website as it's been the result of triaging the ongoing outages.