### PR TITLE
Extend 'Continuous Integration' badge with dev job test stats.

### DIFF
--- a/macro/headers.py
+++ b/macro/headers.py
@@ -345,7 +345,7 @@ def _render_badges(macro, data, badges):
 
                 # if there was any error, skip extending the badge with test stats
                 # and the dropdown
-                if 'error' in  badge:
+                if 'error' in badge:
                     html += '</button>\n'
 
                 else:

--- a/macro/headers.py
+++ b/macro/headers.py
@@ -182,21 +182,7 @@ def _jenkins_stamp_to_datetime(stamp):
     return datetime.datetime.fromtimestamp(stamp).strftime('%d-%b-%Y %H:%M')
 
 
-def get_badges(macro, data):
-    p = macro.formatter.paragraph
-    html = ''
-
-    deprecated = data.get('deprecated', False)
-    if deprecated:
-        html += p(1)
-        html += (
-            '<span class="badge" style="background-color: #f0ad4e;">'
-            '<span class="glyphicon glyphicon-warning-sign" style="color: white;">'
-            '</span> '
-            'Package deprecated</span> %s' % deprecated
-        )
-        html += p(0)
-
+def _process_badge_data(data):
     badges = []
 
     if data.get('release_jobs', []):
@@ -296,8 +282,26 @@ def get_badges(macro, data):
     if not data.get('doc_job', None):
         badges.append({'text' : 'No API documentation', 'color' : color_red, 'icon' : icon_cross})
 
+    return badges
 
-    # render badges to html
+
+def _render_badges(macro, data, badges):
+    p = macro.formatter.paragraph
+    html = ''
+
+    # TODO: refactor this to be more like the other badges
+    deprecated = data.get('deprecated', False)
+    if deprecated:
+        html += p(1)
+        html += (
+            '<span class="badge" style="background-color: #f0ad4e;">'
+            '<span class="glyphicon glyphicon-warning-sign" style="color: white;">'
+            '</span> '
+            'Package deprecated</span> %s' % deprecated
+        )
+        html += p(0)
+
+    # render other badges to html
     if badges:
         html += p(1)
 
@@ -368,6 +372,12 @@ def get_badges(macro, data):
 
         html += p(0)
 
+    return html
+
+
+def get_badges(macro, data):
+    badges = _process_badge_data(data)
+    html = _render_badges(macro, data, badges)
     return html
 
 

--- a/macro/headers.py
+++ b/macro/headers.py
@@ -267,24 +267,26 @@ def _process_badge_data(data):
         badge = {'text' : 'Continuous Integration', 'color' : color_green, 'icon' : icon_checkm}
         badges.append(badge)
 
-        # See if we can 'enhance' the badge by making it reflect jenkins job status.
-        # Assume dict is ok. Any KeyError will be caught and badge contents changed
-        # to indicate an error occured.
-        try:
-            dev_job_data = data['dev_job_data']
-            _process_dev_job_build_data(dev_job_data, badge)
+        # If there is data available, see if we can 'enhance' the badge by
+        # making it reflect jenkins job status.
+        dev_job_data = data.get('dev_job_data', [])
+        if dev_job_data:
+            try:
+                # Any KeyError will be caught and badge contents changed
+                # to indicate an error occured.
+                _process_dev_job_build_data(dev_job_data, badge)
 
-        except KeyError as e:
-            badge['tooltip'] = ("Could not process test statistics, error:\n"
-                                "Missing key in test data: '%s'") % e
-            badge['error'] = e
-            badge['history'] = []
-        except:
-            _, value, tb = sys.exc_info()
-            e = '%s at line %s' % (value.message, tb.tb_lineno)
-            badge['tooltip'] = 'Could not process test statistics, error:\n' + e
-            badge['error'] = e
-            badge['history'] = []
+            except KeyError as e:
+                badge['tooltip'] = ("Could not process test statistics, error:\n"
+                                    "Missing key in test data: '%s'") % e
+                badge['error'] = e
+                badge['history'] = []
+            except:
+                _, value, tb = sys.exc_info()
+                e = '%s at line %s' % (value.message, tb.tb_lineno)
+                badge['tooltip'] = 'Could not process test statistics, error:\n' + e
+                badge['error'] = e
+                badge['history'] = []
 
     if data.get('doc_job', None):
         badges.append({'text' : 'Documented', 'color' : color_green, 'icon' : icon_checkm})

--- a/macro/headers.py
+++ b/macro/headers.py
@@ -270,7 +270,11 @@ def _process_badge_data(data):
         # If there is data available, see if we can 'enhance' the badge by
         # making it reflect jenkins job status.
         dev_job_data = data.get('dev_job_data', [])
-        if dev_job_data:
+        if not dev_job_data:
+            badge['tooltip'] = 'No test statistics available for this package.'
+            badge['error'] = True
+
+        else:
             try:
                 # Any KeyError will be caught and badge contents changed
                 # to indicate an error occured.
@@ -279,13 +283,13 @@ def _process_badge_data(data):
             except KeyError as e:
                 badge['tooltip'] = ("Could not process test statistics, error:\n"
                                     "Missing key in test data: '%s'") % e
-                badge['error'] = e
+                badge['error'] = True
                 badge['history'] = []
             except:
                 _, value, tb = sys.exc_info()
                 e = '%s at line %s' % (value.message, tb.tb_lineno)
                 badge['tooltip'] = 'Could not process test statistics, error:\n' + e
-                badge['error'] = e
+                badge['error'] = True
                 badge['history'] = []
 
     if data.get('doc_job', None):

--- a/macro/headers.py
+++ b/macro/headers.py
@@ -251,7 +251,7 @@ def get_badges(macro, data):
 
                 # create history entry
                 build_ = {
-                    'id' : build['job_id'],
+                    'id' : build['build_id'],
                     'uri' : base_url + '/' + build['uri'],
                     'icon' : build_icon,
                     'stamp' : build_stamp

--- a/macro/headers.py
+++ b/macro/headers.py
@@ -327,7 +327,8 @@ def _render_badges(macro, data, badges):
                 # base badge
                 html += (
                     '<div class="dropdown" style="display: inline-block; margin-bottom: 8px;">'
-                    '<button class="badge dropdown-toggle" style="background-color: #%s; border: none;" data-toggle="dropdown" title="%s">'
+                    '<button class="badge dropdown-toggle" style="background-color: #%s; border: none;"'
+                    ' data-toggle="dropdown" title="%s">'
                     '<span class="glyphicon glyphicon-%s" style="color: white;"></span> %s' % (
                         badge["color"], badge["tooltip"], badge["icon"], badge["text"])
                 )

--- a/macro/headers.py
+++ b/macro/headers.py
@@ -275,6 +275,12 @@ def _process_badge_data(data):
                                 "Missing key in test data: '%s'") % e
             badge['error'] = e
             badge['history'] = []
+        except:
+            _, value, tb = sys.exc_info()
+            e = '%s at line %s' % (value.message, tb.tb_lineno)
+            badge['tooltip'] = 'Could not process test statistics, error:\n' + e
+            badge['error'] = e
+            badge['history'] = []
 
     if data.get('doc_job', None):
         badges.append({'text' : 'Documented', 'color' : color_green, 'icon' : icon_checkm})

--- a/macro/headers.py
+++ b/macro/headers.py
@@ -18,6 +18,7 @@ from macroutils import get_repo_li
 from macroutils import get_url_li
 from macroutils import get_vcs_li
 from macroutils import load_package_manifest
+from macroutils import load_repo_devel_job_data
 from macroutils import load_stack_release
 from macroutils import msg_doc_link
 from macroutils import package_changelog_html_link
@@ -158,6 +159,29 @@ def get_description(macro, data, type_):
     return desc
 
 
+color_green = '5cb85c'
+color_red = 'b94a48'
+color_grey = '999999'
+icon_checkm = 'ok'
+icon_cross = 'remove'
+icon_minus = 'minus'
+
+
+def _map_build_result_to_icon(build_result):
+    if build_result == 'success':
+        return icon_checkm
+    if build_result in ['unstable', 'not_built']:
+        return icon_minus
+    if build_result in ['failure', 'aborted']:
+        return icon_cross
+    # TODO: use better icon for unknown build statuses
+    return icon_minus
+
+
+def _jenkins_stamp_to_datetime(stamp):
+    return datetime.datetime.fromtimestamp(stamp).strftime('%d-%b-%Y %H:%M')
+
+
 def get_badges(macro, data):
     p = macro.formatter.paragraph
     html = ''
@@ -174,25 +198,156 @@ def get_badges(macro, data):
         html += p(0)
 
     badges = []
-    color = '5cb85c'
-    icon = 'ok'
+
     if data.get('release_jobs', []):
-        badges.append(['Released', color, icon])
+        badges.append({'text' : 'Released', 'color' : color_green, 'icon' : icon_checkm})
+
     if data.get('devel_jobs', []):
-        badges.append(['Continuous integration', color, icon])
+        badge = {'text' : 'Continuous Integration', 'color' : color_green, 'icon' : icon_checkm}
+        badges.append(badge)
+
+        # see if we can 'enhance' the badge by making it reflect jenkins job status
+        dev_job_data = data.get('dev_job_data', {})
+        if dev_job_data:
+            base_url = dev_job_data.get('base_url', '')
+            build_history = dev_job_data.get('history', [])
+            latest_build = dev_job_data.get('latest_build', {})
+            tests_skipped = latest_build['skipped']
+            tests_failed = latest_build['failed']
+            tests_total = latest_build['total']
+            # TODO: this essentially considers skipped tests as failures
+            tests_ok = tests_total - tests_failed - tests_skipped
+
+            # update badge dict
+            badge['total_builds'] = dev_job_data.get('total_builds', -1)
+            badge['health'] = dev_job_data.get('job_health', 'n/a')
+            badge['tests_ok'] = tests_ok
+            badge['tests_total'] = tests_total
+
+            if build_history:
+                badge['tooltip'] = text_latest_build = ('Last build:\n'
+                    '  Total tests: %s\n'
+                    '  Succeeded: %s\n'
+                    '  Skipped: %s\n'
+                    '  Failed: %s\n'
+                    '\n'
+                    'Click to show more build history.' % (
+                        tests_total, tests_ok, tests_skipped, tests_failed))
+
+            # set colour and icon based on test results
+            if tests_failed != 0:
+                badge['color'] = color_red
+                badge['icon'] = icon_cross
+            elif tests_skipped != 0:
+                badge['color'] = color_grey
+                badge['icon'] = icon_minus
+
+            # add info on previous builds of the job if there are any
+            badge['history'] = []
+            for build in build_history:
+                # gather build stats
+                build_stamp = _jenkins_stamp_to_datetime(build["stamp"])
+                build_icon = _map_build_result_to_icon(build['result'])
+
+                # create history entry
+                build_ = {
+                    'id' : build['job_id'],
+                    'uri' : base_url + '/' + build['uri'],
+                    'icon' : build_icon,
+                    'stamp' : build_stamp
+                }
+                badge['history'].append(build_)
+
+                # if there is test data available (not all jobs/builds have tests),
+                # add it to the badge data
+                build_test_data = build.get('tests', {})
+                if build_test_data:
+                    tests_skipped = build_test_data['skipped']
+                    tests_failed = build_test_data['failed']
+                    tests_total = build_test_data['total']
+
+                    # TODO: this essentially considers skipped tests as failures
+                    tests_ok = tests_total - tests_failed - tests_skipped
+                    tests_health = round(tests_ok / max(tests_total, 1) * 100.0)
+
+                    build_['health'] = tests_health
+                    build_['tests_ok'] = tests_ok
+                    build_['tests_total'] = tests_total
+
+                else:
+                    build_['health'] = 'n/a'
+                    build_['tests_ok'] = '?'
+                    build_['tests_total'] = '?'
+
+
     if data.get('doc_job', None):
-        badges.append(['Documented', color, icon])
+        badges.append({'text' : 'Documented', 'color' : color_green, 'icon' : icon_checkm})
 
     if not data.get('doc_job', None):
-        badges.append(['No API documentation', 'b94a48', 'remove'])
+        badges.append({'text' : 'No API documentation', 'color' : color_red, 'icon' : icon_cross})
 
+
+    # render badges to html
     if badges:
         html += p(1)
-        html += '\n'.join([
-            '<span class="badge" style="background-color: #%s;">'
-            '<span class="glyphicon glyphicon-%s" style="color: white;"></span> '
-            '%s</span>' % (badge[1], badge[2], badge[0]) for badge in badges
-        ])
+
+        for badge in badges:
+            # all other badges (have only three items in dict)
+            if len(badge) == 3:
+                html += (
+                    '<div class="dropdown" style="display: inline-block; margin-bottom: 8px; margin-right: 4px;">'
+                    '<span class="badge" style="background-color: #%s;">'
+                    '<span class="glyphicon glyphicon-%s" style="color: white;"></span> %s '
+                    '</span>'
+                    '</div>' % (badge["color"], badge["icon"], badge["text"])
+                )
+
+            # the 'Continuous Integration' badge requires special handling
+            else:
+                # base badge
+                html += (
+                    '<div class="dropdown" style="display: inline-block; margin-bottom: 8px;">'
+                    '<button class="badge dropdown-toggle" style="background-color: #%s; border: none;" data-toggle="dropdown" title="%s">'
+                    '<span class="glyphicon glyphicon-%s" style="color: white;"></span> %s: ' % (
+                        badge["color"], badge["tooltip"], badge["icon"], badge["text"])
+                )
+
+                html += '<span>%s / %s</span>\n' % (badge["tests_ok"], badge["tests_total"])
+
+                # add build history, if it exists
+                build_history = badge.get('history', [])
+                if build_history:
+                    html += (
+                        '<span class="caret" style="margin: 0 3px 0 5px;"></span>'
+                        '</button>'
+                        '<ul class="dropdown-menu">'
+                        '<li class="dropdown-header">Build history (last %s of %s builds):</li>'
+                            % (len(badge["history"]), badge["total_builds"])
+                    )
+
+                    for build in badge["history"]:
+                        html += (
+                            '<li style="font-size: 12px">'
+                            '<a href="%s" target="_blank">'
+                            '  <span class="glyphicon glyphicon-%s"></span>'
+                            '  <span style="font-weight: bold; padding-left: 10px;">#%s</span>'
+                            '  <span style="color: #333; padding-left: 10px;">%s</span>'
+                            '  <span style="color: #333; padding-left: 10px;">%s / %s</span>'
+                            '</a>'
+                            '</li>' % (
+                                build["uri"], build["icon"], build["id"], build["stamp"],
+                                build["tests_ok"], build["tests_total"])
+                        )
+
+                    html += '</ul>\n'
+
+                # no history available
+                else:
+                    html += '</button>\n'
+
+                # end of dropdown div
+                html += '</div>\n'
+
         html += p(0)
 
     return html
@@ -362,6 +517,16 @@ def generate_package_header(macro, package_name, opt_distro=None):
         name = "name: %s, distro: %s" % (package_name, opt_distro)
         return CONTRIBUTE_TMPL % locals()
 
+    repo_name = get_repo_name(data, package_name, opt_distro)
+
+    # try to load devel job info (but don't complain if it can't be found or loaded,
+    # as not all devel jobs have been updated (so the results yaml may not exist)
+    try:
+        devel_job_data = load_repo_devel_job_data(repo_name, opt_distro)
+        data.update(devel_job_data)
+    except:
+        pass
+
     nav = []
     # Check to see if the package is a metapackage or a stack
     package_type = data.get('package_type', 'package')
@@ -383,8 +548,6 @@ def generate_package_header(macro, package_name, opt_distro=None):
                         stack_name = metapackage
                 except UtilException:
                     continue
-
-    repo_name = get_repo_name(data, package_name, opt_distro)
 
     desc = get_description(macro, data, 'package')
     links = get_package_links(macro, package_name, data, opt_distro, repo_name=repo_name, metapackage=is_metapackage)

--- a/macro/macroutils.py
+++ b/macro/macroutils.py
@@ -234,7 +234,7 @@ def load_repo_devel_job_data(repo_name, distro=None):
     @return: manifest properties dictionary
     @raise UtilException: if unable to load. Text of error message is human-readable
     """
-    return _load_manifest_file(repo_devel_job_data_file(repo_name, distro), 'SOMETHING')
+    return _load_manifest_file(repo_devel_job_data_file(repo_name, distro), repo_name, 'devel job data for repo')
 
 def load_repo_manifest(repo_name):
     """

--- a/macro/macroutils.py
+++ b/macro/macroutils.py
@@ -46,6 +46,15 @@ def package_manifest_file(package, distro=None):
     else:
         return os.path.join(doc_path, 'api', package, "manifest.yaml")
 
+def repo_devel_job_data_file(repo_name, distro=None):
+    """
+    Generate filesystem path to results.yaml for repository
+    """
+    if distro:
+        return os.path.join(doc_path, distro, 'devel_jobs', repo_name, "results.yaml")
+    else:
+        return os.path.join(doc_path, 'devel_jobs', repo_name, "results.yaml")
+
 def get_package_versions(package):
     distros = []
     for d in distro_names_indexed:
@@ -218,6 +227,14 @@ def load_package_manifest(package_name, distro=None):
     @raise UtilException: if unable to load. Text of error message is human-readable
     """
     return _load_manifest_file(package_manifest_file(package_name, distro), package_name, "package")
+
+def load_repo_devel_job_data(repo_name, distro=None):
+    """
+    Load results.yaml properties into dictionary for repo
+    @return: manifest properties dictionary
+    @raise UtilException: if unable to load. Text of error message is human-readable
+    """
+    return _load_manifest_file(repo_devel_job_data_file(repo_name, distro), 'SOMETHING')
 
 def load_repo_manifest(repo_name):
     """


### PR DESCRIPTION
As per subject. This is the front-end for ros-infrastructure/ros_buildfarm#541.

This PR requires ros-infrastructure/ros_buildfarm#541 to be fully functional (but the `PackageHeader(..)` macro will still work correctly without it).

For a detailed description see the commit comment of 629da38, but summarising: the 'Continuous Integration' badge is modified to not only show whether a repository has a devel job on the buildfarm, but also what the status is of that job and the past `N` builds. It does this in two ways:

 1. show the nr of passing and failing tests, both on the badge as well as for `N` past builds in a drop-down (this is opened onclick, not on mouse-over)
 1. change the colour of the badge to reflect the status. The current mapping of `state -> colour` is as follows:

     - red: failing tests
     - grey: tests were skipped
     - green: all ok

Some examples of badges:

 - packages that are ok:

    ![all_ok](https://user-images.githubusercontent.com/4550046/39300686-dcad59c4-494c-11e8-8df9-5b90a1fe4808.png)

 - packages with skipped tests (note also the tooltip that shows some stats on the latest build without having to open the dropdown):

   ![skipped_tests](https://user-images.githubusercontent.com/4550046/39300706-f0565cf0-494c-11e8-9359-3c228a9b1a98.png)

 - packages with failed tests:

   ![fail](https://user-images.githubusercontent.com/4550046/39300738-027e978a-494d-11e8-995a-529231c9510f.png)

Note that some of these are examples from our internal buildfarm and thus do not reflect the actual status of these packages.

There is a small alignment issue in the drop-down which is due to the fact that `span`s are used (instead of an actual table), this can be addressed in a later PR.

One additional item to be addressed in a later PR is the date+time shown for each build in the drop-down: it currently displays time in the timezone of the wiki server. Some client-side Javascript could be used to show timestamps in the timezone of the rendering browser.

---

This is the first of (hopefully) many contributions to `roswiki` to come out of the [Software Quality Working Group](https://discourse.ros.org/c/quality) of the ROSIN EU H2020 project.
