### PR TITLE
remove Jade from distro_names_buildfarm now that it's EOL

### DIFF
--- a/macro/macroutils.py
+++ b/macro/macroutils.py
@@ -13,7 +13,7 @@ NETWORK_TIMEOUT = 3
 
 distro_names = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'lunar', 'melodic', 'unstable']
 distro_names_indexed = ['diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'lunar', 'melodic', 'unstable'] #boxturtle and cturtle not indexed
-distro_names_buildfarm = ['indigo', 'jade', 'kinetic', 'lunar', 'melodic']
+distro_names_buildfarm = ['indigo', 'kinetic', 'lunar', 'melodic']
 distro_names_never_on_buildfarm = ['boxturtle', 'cturtle', 'diamondback', 'unstable']
 distro_names_eol = [distro for distro in distro_names if distro not in distro_names_buildfarm and distro not in distro_names_never_on_buildfarm]
 


### PR DESCRIPTION
@dhood @tfoote I'm not sure if the meaning of this variable is for distros actively built on the farm (aka that have jobs) or something else?

@dhood Can you see if this allow to hide jade when "Hide EOL distros" is selected ?