### PR TITLE
Improvements to optional EOL version selector

### DIFF
--- a/custom/js/rosversion.js
+++ b/custom/js/rosversion.js
@@ -44,6 +44,11 @@ function getURLParameter(name) {
     )[1].replace(/\+/g, '%20')) || null;
 }
 
+function getHiddenVersionCheckbox()
+{
+  return document.getElementById("rosversions_hidden_checkbox");
+}
+
 function showHiddenVersionSelector(val)
 {
   if (val) {
@@ -51,7 +56,10 @@ function showHiddenVersionSelector(val)
   } else {
     $("#rosversions_hidden").slideUp();
   }
-  document.getElementById("rosversions_hidden_checkbox").checked=val
+  var checkbox = getHiddenVersionCheckbox();
+  if (checkbox) {
+    checkbox.checked=val
+  }
 }
 
 function toggleDocStatus()
@@ -71,6 +79,12 @@ $(document).ready(function() {
   }
 
   // There's a distro selector that is hidden by default (e.g. for EOL distros).
+  // Show it if the checkbox is active already
+  // (e.g. from navigating backward/forward to a page that had it active).
+  var checkbox = getHiddenVersionCheckbox();
+  if (checkbox) {
+    showHiddenVersionSelector(checkbox.checked)
+  }
   // Show it if one of those distros is active.
   if ($("#rosversion_selector_hidden").has("#"+activedistro).length > 0) {
     showHiddenVersionSelector(true);

--- a/macro/PackageHeader.py
+++ b/macro/PackageHeader.py
@@ -48,10 +48,16 @@ def macro_PackageHeader(macro, arg1, arg2=None):
 
         html = ''
         if loaded_distros_buildfarm:
-            html += distro_selector_with_eol_toggle_html(
-                distros_displayed_by_default=loaded_distros_buildfarm,
-                distros_hidden_by_default=loaded_distros_eol,
-            )
+            if loaded_distros_eol:
+                html += distro_selector_with_eol_toggle_html(
+                    distros_displayed_by_default=loaded_distros_buildfarm,
+                    distros_hidden_by_default=loaded_distros_eol,
+                )
+            else:
+                # Only active distros available: don't show EOL toggle.
+                html += distro_selector_html(
+                    distros_displayed=loaded_distros_buildfarm,
+                )
         else:
             # Only EOL distros available: don't show EOL toggle.
             html += (

--- a/macro/PackageHeader.py
+++ b/macro/PackageHeader.py
@@ -2,7 +2,7 @@ from MoinMoin.Page import Page
 from MoinMoin.wikiutil import get_unicode
 
 from macroutils import load_package_manifest, distro_names, distro_names_buildfarm, distro_names_eol, CONTRIBUTE_TMPL, UtilException
-from headers import get_nav, get_description, get_package_links, generate_package_header, distro_selector_html, doc_html, get_loaded_distros
+from headers import get_nav, get_description, get_package_links, generate_package_header, distro_selector_html, distro_selector_with_eol_toggle_html, doc_html, get_loaded_distros
 
 generates_headings = True
 dependencies = []

--- a/macro/PackageHeader.py
+++ b/macro/PackageHeader.py
@@ -59,16 +59,17 @@ def macro_PackageHeader(macro, arg1, arg2=None):
                     distros_displayed=loaded_distros_buildfarm,
                 )
         else:
-            # Only EOL distros available: don't show EOL toggle.
-            html += (
-                '<span style="text-align:left">'
-                '<i>Only released in EOL distros:</i>'
-                '&nbsp;&nbsp;'
-                '</span>'
-            )
-            html += distro_selector_html(
-                distros_displayed=loaded_distros_eol,
-            )
+            if loaded_distros_eol:
+                # Only EOL distros available: don't show EOL toggle.
+                html += (
+                    '<span style="text-align:left">'
+                    '<i>Only released in EOL distros:</i>'
+                    '&nbsp;&nbsp;'
+                    '</span>'
+                )
+                html += distro_selector_html(
+                    distros_displayed=loaded_distros_eol,
+                )
         html += doc_html(loaded_distros, package_name)
         return macro.formatter.rawHTML(html + "\n".join(headers_html))
     else:

--- a/macro/StackHeader.py
+++ b/macro/StackHeader.py
@@ -3,7 +3,7 @@ from MoinMoin.Page import Page
 from MoinMoin.wikiutil import get_unicode
 
 from macroutils import load_stack_manifest, load_package_manifest, distro_names, distro_names_buildfarm, distro_names_eol, CONTRIBUTE_TMPL, UtilException
-from headers import get_nav, get_description, get_package_links, generate_package_header, distro_selector_html, get_stack_links, doc_html, get_loaded_distros
+from headers import get_nav, get_description, get_package_links, generate_package_header, distro_selector_html, distro_selector_with_eol_toggle_html, get_stack_links, doc_html, get_loaded_distros
 
 generates_headings = True
 dependencies = []

--- a/macro/StackHeader.py
+++ b/macro/StackHeader.py
@@ -69,16 +69,17 @@ def macro_StackHeader(macro, arg1, arg2=None):
                     distros_displayed=loaded_distros_buildfarm,
                 )
         else:
-            # Only EOL distros available: don't show EOL toggle.
-            html += (
-                '<span style="text-align:left">'
-                '<i>Only released in EOL distros:</i>'
-                '&nbsp;&nbsp;'
-                '</span>'
-            )
-            html += distro_selector_html(
-                distros_displayed=loaded_distros_eol,
-            )
+            if loaded_distros_eol:
+                # Only EOL distros available: don't show EOL toggle.
+                html += (
+                    '<span style="text-align:left">'
+                    '<i>Only released in EOL distros:</i>'
+                    '&nbsp;&nbsp;'
+                    '</span>'
+                )
+                html += distro_selector_html(
+                    distros_displayed=loaded_distros_eol,
+                )
         html += doc_html(loaded_distros, stack_name)
         return macro.formatter.rawHTML(html + "\n".join(headers_html))
     else:

--- a/macro/StackHeader.py
+++ b/macro/StackHeader.py
@@ -58,10 +58,16 @@ def macro_StackHeader(macro, arg1, arg2=None):
 
         html = ''
         if loaded_distros_buildfarm:
-            html += distro_selector_with_eol_toggle_html(
-                distros_displayed_by_default=loaded_distros_buildfarm,
-                distros_hidden_by_default=loaded_distros_eol,
-            )
+            if loaded_distros_eol:
+                html += distro_selector_with_eol_toggle_html(
+                    distros_displayed_by_default=loaded_distros_buildfarm,
+                    distros_hidden_by_default=loaded_distros_eol,
+                )
+            else:
+                # Only active distros available: don't show EOL toggle.
+                html += distro_selector_html(
+                    distros_displayed=loaded_distros_buildfarm,
+                )
         else:
             # Only EOL distros available: don't show EOL toggle.
             html += (

--- a/macro/headers.py
+++ b/macro/headers.py
@@ -268,12 +268,14 @@ def get_repo_name(data, package_name, opt_distro):
 
 def doc_html(distros, package_name):
     doc_html = (
+        '<div id="doc_status_link" '
+        'style="margin-bottom:10px">'
         '<span style="text-align:left">'
-        '&nbsp;&nbsp;'
         '<a href="javascript:toggleDocStatus()">'
         'Documentation Status'
         '</a>'
         '</span>'
+        '</div>'
     )
     doc_html += (
         '<div id="doc_status" '


### PR DESCRIPTION
Followups to https://github.com/ros-infrastructure/roswiki/pull/204 that I noticed in live testing.

For future reference, pages I tested with include:
only EOL: http://wiki.ros.org/pr2_approach_table
only non-EOL: http://wiki.ros.org/ros_environment
stack header: http://wiki.ros.org/nxt