### PR TITLE
Update search box to load over https

### DIFF
--- a/theme/rostheme.py
+++ b/theme/rostheme.py
@@ -177,7 +177,7 @@ theForm.input.value=theForm.input.value
 </script>
 
 
-<form action="http://www.ros.org/search/index.html" id="cse">
+<form action="https://www.ros.org/search/index.html" id="cse">
   <div>
     <label>Search:</label>
     <input type="hidden" name="cx" value="018259903093183594226:txvzw9fat6w" />


### PR DESCRIPTION
I believe that this is the last http:// resource.

With it updated all the pages I spot checked show green with https urls on the wiki:

![image](https://user-images.githubusercontent.com/447804/40692729-5aff4370-6368-11e8-95e7-bae0b7df0d60.png)
