### PR TITLE
use yaml.safe_load for untrusted yaml input

### DIFF
--- a/macro/MsgSrvDoc.py
+++ b/macro/MsgSrvDoc.py
@@ -59,7 +59,7 @@ def macro_MsgSrvDoc(macro, arg1, arg2='true'):
   except:
     return 'Newly proposed, mistyped, or obsolete package. Could not find package "' + package_name + '" in rosdoc: ' + manifest_file
 
-  m = yaml.load(unicode(ydata, 'utf-8'))
+  m = yaml.safe_load(unicode(ydata, 'utf-8'))
   if not m or type(m) != dict:
     return "Unable to retrieve package data from '%s'. Auto-generated documentation may need to regenerate" % manifest_file
   

--- a/macro/macroutils.py
+++ b/macro/macroutils.py
@@ -213,7 +213,7 @@ def _load_manifest_file(filename, name, type_='package'):
 
     try:
         with open(filename) as f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
     except:
         raise UtilException("Error loading manifest data")        
 


### PR DESCRIPTION
The patch only updates the invocation which are still being used and where untrusted sources are being processed.