### PR TITLE
Remove EOL distros indigo, lunar in macroutils.py

### DIFF
--- a/macro/macroutils.py
+++ b/macro/macroutils.py
@@ -13,7 +13,7 @@ NETWORK_TIMEOUT = 3
 
 distro_names = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'lunar', 'melodic', 'unstable']
 distro_names_indexed = ['diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'lunar', 'melodic', 'unstable'] #boxturtle and cturtle not indexed
-distro_names_buildfarm = ['indigo', 'kinetic', 'lunar', 'melodic']
+distro_names_buildfarm = ['kinetic', 'melodic']
 distro_names_never_on_buildfarm = ['boxturtle', 'cturtle', 'diamondback', 'unstable']
 distro_names_eol = [distro for distro in distro_names if distro not in distro_names_buildfarm and distro not in distro_names_never_on_buildfarm]
 


### PR DESCRIPTION
Not sure if this is the correct way. But as both distros are EOL'd, they IMO shouldn't show up on the ROS wiki by default, but only once I check the "show EOL distros" button.