### PR TITLE
Make Noetic default distro

### DIFF
--- a/custom/js/rosversion.js
+++ b/custom/js/rosversion.js
@@ -72,7 +72,7 @@ function toggleDocStatus()
 }
 
 $(document).ready(function() {
-  var activedistro = "melodic"; //CHANGE THIS LINE TO CHANGE THE DISTRO DISPLAYED BY DEFAULT
+  var activedistro = "noetic"; //CHANGE THIS LINE TO CHANGE THE DISTRO DISPLAYED BY DEFAULT
   var url_distro = getURLParameter('distro');
   if (url_distro) {
     activedistro=url_distro;

--- a/macro/Version.py
+++ b/macro/Version.py
@@ -39,14 +39,9 @@ Dependencies = []
 def execute(macro, args):
     if args:
         version = str(args)
-        if version.lower() == 'noetic':
-            return ('<span style="background-color:#FFFF00; '
-                    'font-weight:bold; padding: 3px;">'
-                    'Expected in Noetic Ninjemys</span>')
-        else:
-            return ('<span style="background-color:#FFFF00; '
-                    'font-weight:bold; padding: 3px;">'
-                    'New in %s</span>' % version)
+        return ('<span style="background-color:#FFFF00; '
+                'font-weight:bold; padding: 3px;">'
+                'New in %s</span>' % version)
 
     html = distro_selector_with_eol_toggle_html(
         distros_displayed_by_default=distro_names_buildfarm,


### PR DESCRIPTION
Same as https://github.com/ros-infrastructure/roswiki/pull/249 to be merged/released on May 23rd

I removed the logic for `Expected in ...` since Noetic is the last ROS 1 release.