### PR TITLE
Mark kinetic as no longer on the buildfarm.

### DIFF
--- a/macro/macroutils.py
+++ b/macro/macroutils.py
@@ -13,7 +13,7 @@ NETWORK_TIMEOUT = 3
 
 distro_names = ['boxturtle', 'cturtle', 'diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'lunar', 'melodic', 'noetic', 'unstable']
 distro_names_indexed = ['diamondback', 'electric', 'fuerte', 'groovy', 'hydro', 'indigo', 'jade', 'kinetic', 'lunar', 'melodic', 'noetic', 'unstable'] #boxturtle and cturtle not indexed
-distro_names_buildfarm = ['kinetic', 'melodic', 'noetic']
+distro_names_buildfarm = ['melodic', 'noetic']
 distro_names_never_on_buildfarm = ['boxturtle', 'cturtle', 'diamondback', 'unstable']
 distro_names_eol = [distro for distro in distro_names if distro not in distro_names_buildfarm and distro not in distro_names_never_on_buildfarm]
 


### PR DESCRIPTION
Which should automatically mark it as EOL.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>